### PR TITLE
Update referred Python version to 3.7.7

### DIFF
--- a/02_python.ps1
+++ b/02_python.ps1
@@ -3,7 +3,7 @@ Function Get-PythonLocation {
         return $Env:GhdlPythonPath
     } else {
         # see https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
-        return "C:\hostedtoolcache\windows\Python\3.7.6\x86"
+        return "C:\hostedtoolcache\windows\Python\3.7.7\x86"
     }
 }
 


### PR DESCRIPTION
Since version 20200430.2 of the Windows Server 2019 virtual environment, the Python version 3.7 has been updated to 3.7.7.

Because of this version mismatch, the build on master is failing since [build #37](https://github.com/MaximilianKoestler/ghdl-build/actions/runs/100474712).